### PR TITLE
Subida

### DIFF
--- a/LabProgramacionAplicaciones/src/main/resources/META-INF/persistence.xml
+++ b/LabProgramacionAplicaciones/src/main/resources/META-INF/persistence.xml
@@ -17,6 +17,7 @@
       <property name="javax.persistence.jdbc.driver" value="com.mysql.cj.jdbc.Driver"/>
       <property name="javax.persistence.jdbc.password" value="tecnologo"/>
       <property name="javax.persistence.schema-generation.database.action" value="create"/>
+      <property name="javax.persistence.sharedCache.mode" value="NONE"/>
     </properties>
   </persistence-unit>
 </persistence>


### PR DESCRIPTION
* Desactivado el cache de la persistencia para evitar que se manejen datos no sincronizados con la BD.